### PR TITLE
updated mark down links to section

### DIFF
--- a/markdown/about/faq.md
+++ b/markdown/about/faq.md
@@ -2,45 +2,43 @@
 title: "FAQ"
 date: "2016-12-05"
 ---
+[**What is Samvera?**](#what-is-samvera)
 
-<h3 id ="01">What is Samvera?</h3>
-<h3 id ="02">Why use Samvera?</h3>
+[**Why use Samvera?**](#why-use-samvera)
 
-[**Why use Samvera?**](#02)
+[**Who uses Samvera, and what for?**](#who-uses-samvera-and-what-for)
 
-[**Who uses Samvera, and what for?**](#03)
+[**How is the Samvera Community governed?**](#how-is-the-samvera-community-governed)
 
-[**How is the Samvera Community governed?**](#04)
+[**What do you mean when you say you are part of a community?  How does that work?**](#what-do-you-mean-when-you-say-you-are-part-of-a-community-how-does-that-work)
 
-[**What do you mean when you say you are part of a community?  How does that work?**](#05)
+[**How can I connect with the Samvera Community and stay up to date on events and developments?**](#how-can-i-connect-with-the-samvera-community-and-stay-up-to-date-on-events-and-developments)
 
-[**How can I connect with the Samvera Community and stay up to date on events and developments?**](#06)
+[**What is the purpose of Samvera Connect and other in-person meetings of the Samvera Community?**](#what-is-the-purpose-of-samvera-connect-and-other-in-person-meetings-of-the-samvera-community)
 
-[**What is the purpose of Samvera Connect and other in-person meetings of the Samvera Community?**](#07)
+[**How do you ensure that everyone can participate in the Samvera Community?**](#how-do-you-ensure-that-everyone-can-participate-in-the-samvera-community)
 
-[**How do you ensure that everyone can participate in the Samvera Community?**](#08)
+[**Where can I download and try Samvera?**](#where-can-i-download-and-try-samvera)
 
-[**Where can I download and try Samvera?**](#09)
+[**Why did Samvera choose the specific components that Samvera repository solutions are based on?**](#why-did-samvera-choose-the-specific-components-that-samvera-repository-solutions-are-based-on)
 
-[**Why did Samvera choose the specific components that Samvera repository solutions are based on?**](#11)
+[**What does it cost to implement Samvera?**](#what-does-it-cost-to-implement-samvera)
 
-[**What does it cost to implement Samvera?**](#12)
+[**I have developed code that could be of use to Samvera.  How can I share this with others?**](#i-have-developed-code-that-could-be-of-use-to-samvera-how-can-i-share-this-with-others)
 
-[**I have developed code that could be of use to Samvera.  How can I share this with others?**](#13)
+[**How do we know Samvera will be around in 5 or 10 years?**](#how-do-we-know-samvera-will-be-around-in-5-or-10-years)
 
-[**How do we know Samvera will be around in 5 or 10 years?**](#14)
+[**Is there an exit strategy for me when I need to move to a different technology?**](#is-there-an-exit-strategy-for-me-when-i-need-to-move-to-a-different-technology)
 
-[**Is there an exit strategy for me when I need to move to a different technology?**](#15)
+[**I have heard the terms Hydra, Hyrax, Hyku, and HyBox associated with Samvera-what do they all mean?**](#i-have-heard-the-terms-hydra-hyrax-hyku-and-hybox-associated-with-samvera-what-do-they-all-mean)
 
-[**I’ve heard the terms Hydra, Hyrax, Hyku, and HyBox associated with Samvera—what do they all mean?**](#16)
+[**My institution is moving more and more into the cloud.  Can I have Samvera in the cloud?**](#my-institution-is-moving-more-and-more-into-the-cloud-can-i-have-samvera-in-the-cloud)
 
-[**My institution is moving more and more into the cloud.  Can I have Samvera in the cloud?**](#17)
-
-[**What does Samvera offer that DSpace, EPrints, ContentDM, Islandora, etc. do not?**](#18)
+[**What does Samvera offer that DSpace, EPrints, ContentDM, Islandora, etc. do not? What makes the Samvera approach to repositories stand out?**](#what-does-samvera-offer-that-dspace-eprints-contentdm-islandora-etc-do-not-what-makes-the-samvera-approach-to-repositories-stand-out)
 
 * * *
 
-**What is Samvera?**
+# What is Samvera?
 
 The name Samvera is an Icelandic term meaning "togetherness."  Samvera is a grass-roots, open-source community of library professionals, including repository managers, developers, metadata experts, content owners and users, working together to create best-in-class digital repository solutions.  The scope of the community encompasses work for Libraries, Archives, Museums and others. Read more about the [Samvera Community Framework](http://samvera.org/samvera-partners/community-framework/) on our website.
 
@@ -55,7 +53,7 @@ The combination of the components is consciously modular to enable individual so
 
 * * *
 
-**Why use Samvera?**
+# Why use Samvera?
 
 We believe that no single repository system can provide the full range of repository-based solutions for a given institution’s needs; likewise, no single institution can resource the development of a full range of solutions on its own.  Samvera is an open-source repository solution built collaboratively to address a broad range of repository needs. Rather than being one-size-fits-all, Samvera leverages an ecosystem of components that lets institutions assemble and deploy robust and durable repository applications that are tailored to their users' needs and workflows. 
 
@@ -65,7 +63,7 @@ As a grass-roots, open-source software producer, the Samvera Community is accoun
 
 * * *
 
-**Who uses Samvera, and what for?**
+# Who uses Samvera, and what for?
 
 Read about [implementations of Samvera](https://samvera.atlassian.net/wiki/spaces/samvera/pages/422319621/Samvera+Implementations+In-production) on our wiki.  At a host of educational and cultural institutions, Samvera is currently in use to:
 
@@ -77,7 +75,7 @@ For more details about Samvera use cases and links out to current Samvera applic
 
 * * *
 
-**How is the Samvera Community governed?**
+# How is the Samvera Community governed?
 
 Samvera is a community, and, as such, it is governed by members of the community.  The [Samvera Partners](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405210590/Samvera+Community+Framework) are at the heart of how Samvera operates.  They encompass groups that coordinate effort across multiple institutions and development efforts. These include the Board, the Roadmap Alignment Group and the Component Maintenance Group, as well as project-specific teams that focus on particular efforts such as the Avalon Media System, Hyrax, and Hyku solution bundles.
 
@@ -87,7 +85,7 @@ All technical work is carried out according to the [Samvera Community Principles
 
 * * *
 
-**What do you mean when you say you are part of a community?  How does that work?**
+# What do you mean when you say you are part of a community?  How does that work?
 
 The people involved in developing ideas and software within the Samvera Community are also those using the solutions created. They thus have a close understanding of the needs. Participation in the Samvera Community is invited at different levels: organizations can join as Partners or Adopters.  Partners take a more active and formal role in the development of Samvera, but all are welcome to contribute as they can. Contributing to the community can take many forms: developing the codebase, developing metadata, contributing to documentation and marketing efforts, or simply adopting the Samvera technology and communicating about that experience.  The Samvera Community has multiple open [Interest and Working Groups](https://samvera.atlassian.net/wiki/spaces/samvera/pages/422319284/Interest+Group+IG+and+Working+Group+WG+Hub) managing the community itself and contributing at various levels to the development of its outputs. Work is managed in concert with other users to ensure that the Samvera technology meets as many shared needs as possible.
 
@@ -95,19 +93,19 @@ Contributing to the community is not a one-way street—what we invest in terms 
 
 * * *
 
-**How can I connect with the Samvera Community and stay up to date on events and developments?**
+# How can I connect with the Samvera Community and stay up to date on events and developments?
 
 There are several ways to connect with the Samvera Community, and you can find them all on our [Getting Started wiki page](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211682/Getting+Started+in+the+Samvera+Community).  Newcomers to the community are encouraged to join the [Samvera Community Google Group](https://groups.google.com/g/samvera-community) and participate in Samvera on Slack.  Samvera Partner institutions are encouraged to join the [Samvera Partners Google Group](https://groups.google.com/g/samvera-partners). Samvera channels on Slack are open for anyone to follow.  Slack #general covers issues pertinent to the community at large, whilst for developers there is Slack #dev.  There is also a specific channel for those interested in attending our annual Samvera Connect conference, Slack #connect.  The [Samvera wiki](https://samvera.atlassian.net/wiki/spaces/samvera/overview?mode=global) provides a lot of additional detailed information on Samvera Community activity and its '[Get in touch!](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211682/Get+in+touch)' page contains a fuller list of our communication channels .
 
 * * *
 
-**What is the purpose of Samvera Connect and other in-person meetings of the Samvera Community?**
+# What is the purpose of Samvera Connect and other in-person meetings of the Samvera Community?
 
 Face-to-face community events maximize the value of participation in Samvera by providing opportunities for Adopters to share local efforts and benefit from the vast experience and expertise of others in shared knowledge and practice.  In-person community events are staff development, training, and networking opportunities all rolled into one. By investing in staff attendance at Samvera Connect and other meetings, an organization can be assured that staff members are supported to learn skills and gain expertise that directly impacts the development and delivery of their Samvera-based repository.  We really do go further together.
 
 * * *
 
-**How do you ensure that everyone can participate in the Samvera Community?**
+# How do you ensure that everyone can participate in the Samvera Community?
 
 The Samvera Community takes the inclusion of everyone who wishes to participate very seriously.  A [Code of Conduct](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405212316/Code+of+Conduct) and [Anti-Harassment Policy](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211680/Anti-Harassment+Policy) has been published, and a community group of [Samvera Helpers](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211681/Samvera+Community+Helpers) provides an email address and individual contact points where any behavior that is not in keeping with Samvera’s principles can be flagged for attention and action.  This approach is applied within both the physical and virtual channels through which community members interact.
 
@@ -115,13 +113,13 @@ The continuing need to find ways of enabling under-represented groups within our
 
 * * *
 
-**Where can I download and try Samvera?**
+# Where can I download and try Samvera?
 
 All the software is available through the Samvera Community's [Github](https://github.com/samvera).  Documentation is available at [http://samvera.github.io/](http://samvera.github.io/).  A test instance of the Hyrax implementation of the Samvera framework is made available by Data Curation Experts (DCE) at [https://nurax.curationexperts.com/](https://nurax.curationexperts.com/).
 
 * * *
 
-**Why did Samvera choose the specific components that Samvera repository solutions are based on?**
+# Why did Samvera choose the specific components that Samvera repository solutions are based on?
 
 The components that form the basis of Samvera’s solutions (Fedora, Blacklight, Solr) were selected as well-designed services in their own right, and in recognition of their successful use in existing services.  Samvera has created associated components (Samvera gems) to bring them together in ways that make them more than the sum of their parts.
 
@@ -129,7 +127,7 @@ The Samvera architecture was always designed to allow for individual components 
 
 * * *
 
-**What does it cost to implement Samvera?**
+# What does it cost to implement Samvera?
 
 Samvera software is free and open-source, but of course, this is free in the same way that stray puppies come free: you will have your own ongoing support and maintenance costs to look after it.  Depending on the complexity and degree of local customization you require in your implementation, areas of cost to your institution may include:
 
@@ -147,13 +145,13 @@ Implementing Samvera is also an important investment in the future of sustainabl
 
 * * *
 
-**I have developed code that could be of use to Samvera.  How can I share this with others?**
+# I have developed code that could be of use to Samvera.  How can I share this with others?
 
 Firstly, thank you for considering sharing your work with Samvera, it’s very much appreciated.  There is guidance on making technical contributions to Samvera available on our [Documentation](https://samvera.github.io/tag_community.html) site.  Please also note that we require all contributions to be licensed via a completed [Contributor Licensing Agreement](https://samvera.atlassian.net/wiki/spaces/samvera/pages/405211651/Samvera+Community+Intellectual+Property+Licensing+and+Ownership) to ensure clarity in how Samvera can continue to make use of code you created.
 
 * * *
 
-**How do we know Samvera will be around in 5 or 10 years?**
+# How do we know Samvera will be around in 5 or 10 years?
 
 Samvera leverages the convening power of institutions, which outlasts the ebb and flow of vendor cycles. Since the founding of the Samvera Community in 2008, Partner institutions have made substantial investments, both financially and in terms of staff time, in the Samvera Community and technologies.  There are now over thirty Partners who have contributed to sustainability-minded investments including funding to enable the hiring of a Community Manager; moving to a 501(c)6 foundation model; and moving to a fully elected Board.
 
@@ -161,13 +159,13 @@ These investments, in addition to the steadily growing number of Samvera Adopter
 
 * * *
 
-**Is there an exit strategy for me when I need to move on?**
+# Is there an exit strategy for me when I need to move to a different technology?
 
 We know that nothing lasts forever and that some of our community will probably wish to move on to other, non-Samvera solutions in time.  In keeping with Samvera’s use of open source components, it is important that the content being managed should be openly transferable to facilitate its management over time regardless of the software being used.  To support this Samvera is developing bulk import and export capability: the latter will allow the contents of a Samvera repository to be exported in a way that might be migrated to other platforms.
 
 * * *
 
-**I’ve heard the terms Hydra, Hyrax, Hyku, and HyBox associated with Samvera—what do they all mean?**
+# I have heard the terms Hydra, Hyrax, Hyku, and HyBox associated with Samvera what do they all mean?
 
 Samvera started as the Hydra Project in 2008, and changed to its current name in 2017: this change was community-led and based on a vote taken among members of the Community.  For a history of the development of Samvera from its Hydra roots, see the [article published in Insights](https://insights.uksg.org/articles/10.1629/uksg.383/) in November 2017.
 
@@ -177,13 +175,13 @@ Hyku is the product release from the Hydra-in-a-Box (HyBox) project and it is bu
 
 * * *
 
-**My institution is moving more and more into the cloud.  Can I have Samvera in the cloud?**
+# My institution is moving more and more into the cloud.  Can I have Samvera in the cloud?
 
 Hyku was created specifically to work in the cloud as a multi-tenanted solution for delivering repository solutions.  Several Samvera repositories are also deployed or partially deployed via Amazon Web Services (AWS). Amazon Machine Images (AMIs), docker storage, and other cloud-friendly technologies are being used to support Samvera deployment and components of Samvera solution bundles.  For example: the [Avalon](http://www.avalonmediasystem.org/project) Media System, an implementation of the Samvera framework focused on media content, is fully deployable in AWS and uses AWS transcoding to create multiple bitrate versions of uploaded content.
 
 * * *
 
-**What does Samvera offer that DSpace, EPrints, ContentDM, Islandora, etc. do not? What makes the Samvera approach to repositories stand out?**
+# What does Samvera offer that DSpace, EPrints, ContentDM, Islandora, etc. do not? What makes the Samvera approach to repositories stand out?
 
 Many repository systems offer useful features to meet repository needs.  As well as offering a proven open-source solution, Samvera comes with an active, engaged community to work with on shared development to improve the technologies and modify them as required to integrate new tools and functions.  Members of the community are always available through the Samvera Slack channels or through our Google Groups and are always willing to answer queries where they can.  Samvera offers flexibility in managing different types of digital assets, including audiovisual and geospatial data. It provides the ability to curate and build exhibits from a single database. And it offers the flexibility to start small and plan to grow, in stages that you can manage in line with your needs and budget.
 


### PR DESCRIPTION
I added the section headings to the markdown links (replacing the #numbers). Each link now leads to the corresponsing header